### PR TITLE
Change "main" to cjs instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "temml",
   "version": "0.10.3",
   "description": "TeX to MathML conversion in JavaScript.",
-  "main": "dist/temml.js",
+  "main": "dist/temml.cjs",
   "homepage": "https://temml.org",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I'm pretty sure only node needs the "main" term for the understanding of how the module is loaded.  Everything else will use the js and min.js through direct pointers.  As is, after doing an npm install temml, you cannot use the package in node because it wants to look at temml.js and exports an empty object.